### PR TITLE
Remove knowledge of next states  from vm classes

### DIFF
--- a/plugin/cmd/mocks/vbox.go
+++ b/plugin/cmd/mocks/vbox.go
@@ -4,9 +4,9 @@
 package mocks
 
 import (
-	"github.com/golang/mock/gomock"
-	"github.com/pivotal-cf/pcfdev-cli/config"
-	"github.com/pivotal-cf/pcfdev-cli/vboxdriver"
+	gomock "github.com/golang/mock/gomock"
+	config "github.com/pivotal-cf/pcfdev-cli/config"
+	vboxdriver "github.com/pivotal-cf/pcfdev-cli/vboxdriver"
 )
 
 // Mock of VBox interface

--- a/plugin/cmd/start.go
+++ b/plugin/cmd/start.go
@@ -55,6 +55,7 @@ func (s *StartCmd) Parse(args []string) error {
 		CPUs:           s.flagContext.Int("c"),
 		Memory:         uint64(s.flagContext.Int("m")),
 		NoProvision:    s.flagContext.Bool("n"),
+		Provision:      s.flagContext.Bool("p"),
 		OVAPath:        s.flagContext.String("o"),
 		Registries:     s.flagContext.String("r"),
 		Services:       s.flagContext.String("s"),
@@ -85,34 +86,31 @@ func (s *StartCmd) Run() error {
 		return err
 	}
 
-	if s.flagContext.Bool("p") {
-		return v.Provision(&vm.StartOpts{})
-	} else {
-		if err := v.VerifyStartOpts(s.Opts); err != nil {
-			return err
-		}
-		if !s.isCustomOva() {
-			if err := s.DownloadCmd.Run(); err != nil {
-				return err
-			}
-		}
-
-		if err := v.Start(s.Opts); err != nil {
-			return err
-		}
-
-		if s.flagContext.Bool("k") {
-			if err := s.AutoTrustCmd.Run(); err != nil {
-				return err
-			}
-		}
-
-		if s.flagContext.Bool("t") {
-			return s.TargetCmd.Run()
-		}
-
-		return nil
+	if err := v.VerifyStartOpts(s.Opts); err != nil {
+		return err
 	}
+	if !s.isCustomOva() {
+		if err := s.DownloadCmd.Run(); err != nil {
+			return err
+		}
+	}
+
+	if err := v.Start(s.Opts); err != nil {
+		return err
+	}
+
+	if s.flagContext.Bool("k") {
+		if err := s.AutoTrustCmd.Run(); err != nil {
+			return err
+		}
+	}
+
+	if s.flagContext.Bool("t") {
+		return s.TargetCmd.Run()
+	}
+
+	return nil
+
 }
 
 func (s *StartCmd) isIncompatibleVBox() error {

--- a/plugin/cmd/start.go
+++ b/plugin/cmd/start.go
@@ -145,15 +145,11 @@ func (s *StartCmd) vmIsOld() bool {
 }
 
 func (s *StartCmd) switchingToCustomOva() bool {
-	if s.existingVMName != "" && s.Opts.OVAPath != "" && s.existingVMName != "pcfdev-custom" {
-		return true
-	} else {
-		return false
-	}
+	return s.existingVMName != "" && s.Opts.OVAPath != "" && s.existingVMName != "pcfdev-custom"
 }
 
 func (s *StartCmd) isCustomOva() bool {
-	return (s.Opts.OVAPath != "" || s.existingVMName == "pcfdev-custom")
+	return s.Opts.OVAPath != "" || s.existingVMName == "pcfdev-custom"
 }
 
 func (s *StartCmd) vmName() string {

--- a/plugin/cmd/start_test.go
+++ b/plugin/cmd/start_test.go
@@ -65,6 +65,7 @@ var _ = Describe("StartCmd", func() {
 					"-k",
 					"-m", "3456",
 					"-n",
+					"-p",
 					"-o", "some-ova-path",
 					"-r", "some-private-registry,some-other-private-registry",
 					"-s", "some-service,some-other-service",
@@ -76,6 +77,7 @@ var _ = Describe("StartCmd", func() {
 				Expect(startCmd.Opts.CPUs).To(Equal(2))
 				Expect(startCmd.Opts.Memory).To(Equal(uint64(3456)))
 				Expect(startCmd.Opts.NoProvision).To(BeTrue())
+				Expect(startCmd.Opts.Provision).To(BeTrue())
 				Expect(startCmd.Opts.OVAPath).To(Equal("some-ova-path"))
 				Expect(startCmd.Opts.Registries).To(Equal("some-private-registry,some-other-private-registry"))
 				Expect(startCmd.Opts.Services).To(Equal("some-service,some-other-service"))
@@ -92,6 +94,7 @@ var _ = Describe("StartCmd", func() {
 				Expect(startCmd.Opts.CPUs).To(Equal(0))
 				Expect(startCmd.Opts.Memory).To(Equal(uint64(0)))
 				Expect(startCmd.Opts.NoProvision).To(BeFalse())
+				Expect(startCmd.Opts.Provision).To(BeFalse())
 				Expect(startCmd.Opts.OVAPath).To(BeEmpty())
 				Expect(startCmd.Opts.Registries).To(BeEmpty())
 				Expect(startCmd.Opts.Services).To(BeEmpty())
@@ -401,36 +404,6 @@ var _ = Describe("StartCmd", func() {
 					mockVBox.EXPECT().GetVMName().Return("some-old-vm-name", nil)
 					Expect(startCmd.Run()).To(MatchError("you must destroy your existing VM to use a custom OVA"))
 				})
-			})
-		})
-
-		Context("when the provision option is specified", func() {
-			It("should provision the VM", func() {
-				startCmd.Parse([]string{"-p"})
-
-				gomock.InOrder(
-					mockVBox.EXPECT().Version().Return(&vboxdriver.VBoxDriverVersion{Major: 5}, nil),
-					mockVBox.EXPECT().GetVMName().Return("", nil),
-					mockVMBuilder.EXPECT().VM("some-default-vm-name").Return(mockVM, nil),
-					mockVM.EXPECT().Provision(&vm.StartOpts{}),
-				)
-
-				Expect(startCmd.Run()).To(Succeed())
-			})
-		})
-
-		Context("when provisioning fails", func() {
-			It("return an error", func() {
-				startCmd.Parse([]string{"-p"})
-
-				gomock.InOrder(
-					mockVBox.EXPECT().Version().Return(&vboxdriver.VBoxDriverVersion{Major: 5}, nil),
-					mockVBox.EXPECT().GetVMName().Return("", nil),
-					mockVMBuilder.EXPECT().VM("some-default-vm-name").Return(mockVM, nil),
-					mockVM.EXPECT().Provision(&vm.StartOpts{}).Return(errors.New("some-error")),
-				)
-
-				Expect(startCmd.Run()).To(MatchError("some-error"))
 			})
 		})
 	})

--- a/vbox/mocks/driver.go
+++ b/vbox/mocks/driver.go
@@ -4,9 +4,9 @@
 package mocks
 
 import (
-	"github.com/golang/mock/gomock"
-	"github.com/pivotal-cf/pcfdev-cli/network"
-	"github.com/pivotal-cf/pcfdev-cli/vboxdriver"
+	gomock "github.com/golang/mock/gomock"
+	network "github.com/pivotal-cf/pcfdev-cli/network"
+	vboxdriver "github.com/pivotal-cf/pcfdev-cli/vboxdriver"
 )
 
 // Mock of Driver interface

--- a/vm/invalid.go
+++ b/vm/invalid.go
@@ -18,10 +18,6 @@ func (i *Invalid) Start(opts *StartOpts) error {
 	return i.err()
 }
 
-func (i *Invalid) Provision(opts *StartOpts) error {
-	return i.err()
-}
-
 func (i *Invalid) Status() string {
 	return i.message()
 }

--- a/vm/mocks/vm.go
+++ b/vm/mocks/vm.go
@@ -39,16 +39,6 @@ func (_mr *_MockVMRecorder) GetDebugLogs() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDebugLogs")
 }
 
-func (_m *MockVM) Provision(_param0 *vm.StartOpts) error {
-	ret := _m.ctrl.Call(_m, "Provision", _param0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVMRecorder) Provision(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Provision", arg0)
-}
-
 func (_m *MockVM) Resume() error {
 	ret := _m.ctrl.Call(_m, "Resume")
 	ret0, _ := ret[0].(error)

--- a/vm/not_created.go
+++ b/vm/not_created.go
@@ -115,10 +115,6 @@ func (n *NotCreated) hasSCS(services string) bool {
 	return strings.Contains(services, "scs") || strings.Contains(services, "spring-cloud-services") || strings.Contains(services, "all")
 }
 
-func (n *NotCreated) Provision(opts *StartOpts) error {
-	return nil
-}
-
 func (n *NotCreated) Start(opts *StartOpts) error {
 	var memory uint64
 	if opts.Memory != uint64(0) {

--- a/vm/paused.go
+++ b/vm/paused.go
@@ -46,10 +46,6 @@ func (p *Paused) Start(opts *StartOpts) error {
 	return p.Resume()
 }
 
-func (p *Paused) Provision(opts *StartOpts) error {
-	return nil
-}
-
 func (p *Paused) Status() string {
 	return "Suspended - system memory for the VM is still allocated. Resume and suspend to suspend pcfdev VM to the disk."
 }

--- a/vm/running_test.go
+++ b/vm/running_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Running", func() {
 		})
 	})
 
-	Describe("Provision", func() {
+	Describe("Start - with reprovision", func() {
 		It("should provision the VM", func() {
 			sshAddresses := []ssh.SSHAddress{
 				{IP: "127.0.0.1", Port: "some-port"},
@@ -161,10 +161,10 @@ var _ = Describe("Running", func() {
 				mockFS.EXPECT().Read("some-private-key-path").Return([]byte("some-private-key"), nil),
 				mockSSH.EXPECT().GetSSHOutput("sudo rm -f /run/pcfdev-healthcheck", sshAddresses, []byte("some-private-key"), 30*time.Second).Return("", nil),
 				mockBuilder.EXPECT().VM("some-vm").Return(mockVM, nil),
-				mockVM.EXPECT().Provision(&vm.StartOpts{}),
+				mockVM.EXPECT().Start(&vm.StartOpts{Provision: true}),
 			)
 
-			runningVM.Provision(&vm.StartOpts{})
+			runningVM.Start(&vm.StartOpts{Provision: true})
 		})
 
 		Context("when removing healthcheck file fails", func() {
@@ -178,7 +178,7 @@ var _ = Describe("Running", func() {
 					mockSSH.EXPECT().GetSSHOutput("sudo rm -f /run/pcfdev-healthcheck", sshAddresses, []byte("some-private-key"), 30*time.Second).Return("", errors.New("some-error")),
 				)
 
-				Expect(runningVM.Provision(&vm.StartOpts{})).To(MatchError("some-error"))
+				Expect(runningVM.Start(&vm.StartOpts{Provision: true})).To(MatchError("some-error"))
 			})
 		})
 
@@ -186,7 +186,7 @@ var _ = Describe("Running", func() {
 			It("should return an error", func() {
 				mockFS.EXPECT().Read("some-private-key-path").Return(nil, errors.New("some-error"))
 
-				Expect(runningVM.Provision(&vm.StartOpts{})).To(MatchError("some-error"))
+				Expect(runningVM.Start(&vm.StartOpts{Provision: true})).To(MatchError("some-error"))
 			})
 		})
 
@@ -202,7 +202,7 @@ var _ = Describe("Running", func() {
 					mockBuilder.EXPECT().VM("some-vm").Return(nil, errors.New("some-error")),
 				)
 
-				Expect(runningVM.Provision(&vm.StartOpts{})).To(MatchError("some-error"))
+				Expect(runningVM.Start(&vm.StartOpts{Provision: true})).To(MatchError("some-error"))
 			})
 		})
 
@@ -216,10 +216,10 @@ var _ = Describe("Running", func() {
 					mockFS.EXPECT().Read("some-private-key-path").Return([]byte("some-private-key"), nil),
 					mockSSH.EXPECT().GetSSHOutput("sudo rm -f /run/pcfdev-healthcheck", sshAddresses, []byte("some-private-key"), 30*time.Second).Return("", nil),
 					mockBuilder.EXPECT().VM("some-vm").Return(mockVM, nil),
-					mockVM.EXPECT().Provision(&vm.StartOpts{}).Return(errors.New("some-error")),
+					mockVM.EXPECT().Start(&vm.StartOpts{Provision: true}).Return(errors.New("some-error")),
 				)
 
-				Expect(runningVM.Provision(&vm.StartOpts{})).To(MatchError("some-error"))
+				Expect(runningVM.Start(&vm.StartOpts{Provision: true})).To(MatchError("some-error"))
 			})
 		})
 	})

--- a/vm/saved.go
+++ b/vm/saved.go
@@ -45,10 +45,6 @@ func (s *Saved) Start(opts *StartOpts) error {
 	return s.Resume()
 }
 
-func (s *Saved) Provision(opts *StartOpts) error {
-	return nil
-}
-
 func (s *Saved) Stop() error {
 	s.UI.Say("Your VM is currently suspended. You must resume your VM with `cf dev resume` to shut it down.")
 	return nil

--- a/vm/stopped.go
+++ b/vm/stopped.go
@@ -141,7 +141,9 @@ func (s *Stopped) Start(opts *StartOpts) error {
 		return nil
 	}
 
-	return unprovisionedVM.Provision(opts)
+	opts.Provision = true
+
+	return unprovisionedVM.Start(opts)
 }
 
 func (s *Stopped) Provision(opts *StartOpts) error {

--- a/vm/stopped_test.go
+++ b/vm/stopped_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Stopped", func() {
 			mockVBox.EXPECT().StartVM(gomock.Any()).AnyTimes()
 			mockBuilder.EXPECT().VM(gomock.Any()).AnyTimes().Return(mockUnprovisioned, nil)
 			mockFS.EXPECT().Read(gomock.Any()).AnyTimes().Return([]byte("some-private-key"), nil)
-			mockUnprovisioned.EXPECT().Provision(gomock.Any()).AnyTimes()
+			mockUnprovisioned.EXPECT().Start(gomock.Any()).AnyTimes()
 		}
 
 		Context("when 'none' services are specified", func() {
@@ -187,7 +187,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "none"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "none"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "none"})
@@ -204,7 +204,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,redis,spring-cloud-services","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "all"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "all"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "all"})
@@ -221,7 +221,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,redis","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "default"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "default"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "default"})
@@ -238,7 +238,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,spring-cloud-services","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "spring-cloud-services"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "spring-cloud-services"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "spring-cloud-services"})
@@ -255,7 +255,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,spring-cloud-services","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "scs"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "scs"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "scs"})
@@ -272,7 +272,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "rabbitmq"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "rabbitmq"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "rabbitmq"})
@@ -289,7 +289,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"redis","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "redis"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "redis"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "redis"})
@@ -306,7 +306,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "mysql"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "mysql"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "mysql"})
@@ -323,7 +323,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,redis,spring-cloud-services","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Services: "default,spring-cloud-services,scs"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Services: "default,spring-cloud-services,scs"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Services: "default,spring-cloud-services,scs"})
@@ -340,7 +340,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,redis","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{})
@@ -357,7 +357,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-custom-ip","services":"rabbitmq,redis","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{IP: "some-custom-ip"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, IP: "some-custom-ip"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{IP: "some-custom-ip"})
@@ -374,7 +374,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-custom-domain","ip":"some-ip","services":"rabbitmq,redis","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Domain: "some-custom-domain"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Domain: "some-custom-domain"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Domain: "some-custom-domain"})
@@ -391,7 +391,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,redis","registries":["some-private-registry","some-other-private-registry"],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{Registries: "some-private-registry,some-other-private-registry"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, Registries: "some-private-registry,some-other-private-registry"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{Registries: "some-private-registry,some-other-private-registry"})
@@ -408,7 +408,7 @@ var _ = Describe("Stopped", func() {
 					mockSSH.EXPECT().RunSSHCommand("echo "+
 						`'{"domain":"some-domain","ip":"some-ip","services":"rabbitmq,redis","registries":[],"provider":"some-provider"}' | sudo tee /var/pcfdev/provision-options.json >/dev/null`,
 						addresses, []byte("some-private-key"), 5*time.Minute, os.Stdout, os.Stderr),
-					mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{MasterPassword: "some-master-password"}),
+					mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true, MasterPassword: "some-master-password"}),
 				)
 
 				stoppedVM.Start(&vm.StartOpts{MasterPassword: "some-master-password"})
@@ -473,7 +473,7 @@ var _ = Describe("Stopped", func() {
 
 		Context("when provisioning the unprovisioned vm fails", func() {
 			It("should return an error", func() {
-				mockUnprovisioned.EXPECT().Provision(&vm.StartOpts{}).Return(errors.New("some-error"))
+				mockUnprovisioned.EXPECT().Start(&vm.StartOpts{Provision: true}).Return(errors.New("some-error"))
 				allowHappyPathInteractions()
 				Expect(stoppedVM.Start(&vm.StartOpts{})).To(MatchError("some-error"))
 			})

--- a/vm/unprovisioned.go
+++ b/vm/unprovisioned.go
@@ -39,14 +39,10 @@ func (u *Unprovisioned) VerifyStartOpts(opts *StartOpts) error {
 }
 
 func (u *Unprovisioned) Start(opts *StartOpts) error {
-	return u.err()
-}
+	if !opts.Provision {
+		return u.err()
+	}
 
-func (u *Unprovisioned) Status() string {
-	return u.err().Error()
-}
-
-func (u *Unprovisioned) Provision(opts *StartOpts) error {
 	if opts.MasterPassword != "" {
 		privateKey, err := u.FS.Read(u.Config.PrivateKeyPath)
 		if err != nil {
@@ -97,6 +93,10 @@ func (u *Unprovisioned) Provision(opts *StartOpts) error {
 	u.HelpText.Print(u.VMConfig.Domain, opts.Target)
 
 	return nil
+}
+
+func (u *Unprovisioned) Status() string {
+	return u.err().Error()
 }
 
 func (u *Unprovisioned) Suspend() error {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -41,7 +41,6 @@ type SSH interface {
 //go:generate mockgen -package mocks -destination mocks/vm.go github.com/pivotal-cf/pcfdev-cli/vm VM
 type VM interface {
 	Start(*StartOpts) error
-	Provision(*StartOpts) error
 	Stop() error
 	Status() string
 	Suspend() error
@@ -109,6 +108,7 @@ type StartOpts struct {
 	CPUs           int
 	Memory         uint64
 	NoProvision    bool
+	Provision      bool
 	OVAPath        string
 	Registries     string
 	Services       string


### PR DESCRIPTION
[#134586993]

I'm [mutating the StartCmd struct's existingName](https://github.com/pivotal-cf/pcfdev-cli/compare/features/move-state-knowledge-from-vms-to-commands?expand=1#diff-66cd81aff5c6000c17057f4a1fe5134eR75) because we don't know it on construction and retrieving it could throw an error. I went with this over passing down existingName to all of the helpers methods.

@mdelillo @chhhavi